### PR TITLE
Remove legacy header guard

### DIFF
--- a/ios/RNCarnival.h
+++ b/ios/RNCarnival.h
@@ -1,11 +1,6 @@
 
-#if __has_include("RCTBridgeModule.h")
-    #import "RCTBridgeModule.h"
-    #import "RCTEventEmitter.h"
-#else
-    #import <React/RCTBridgeModule.h>
-    #import <React/RCTEventEmitter.h>
-#endif
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
 #include <Carnival/Carnival.h>
 


### PR DESCRIPTION
This guard was designed to allow backwards compatibility with React Native versions <0.40. Since we now support 0.48+ anyway and the some issues have been reported with this in newer builds I have removed it. 