### PR TITLE
[MOBILE-648] Fix Android Session Opens

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Then add a call to startEngine to the native AppDelegate.m
 #import <Carnival/Carnival.h>
 
 - (BOOL)application:(UIApplication * )application didFinishLaunchingWithOptions:(NSDictionary * )launchOptions {
-	[Carnival startEngine:SDK_KEY]; // Obtain SDK key from your Carnival app settings
-  return YES;
+      [Carnival startEngine:SDK_KEY]; // Obtain SDK key from your Carnival app settings
+      return YES;
 }
 ```
 
@@ -68,6 +68,7 @@ dependencies {
 
 ```java
 import com.reactlibrary.RNCarnivalPackage; // <--- import
+import com.carnival.sdk.Carnival;          // <--- import
 
 public class MainApplication extends Application implements ReactApplication {
   ...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Native : Carnival SDK
 
-Wraps the native Carnival SDK for React Native apps. 
+Wraps the native Carnival SDK for React Native apps.
 
 ## Installation
 
@@ -9,7 +9,7 @@ Wraps the native Carnival SDK for React Native apps.
 
 ### iOS
 
-Open your Project's Xcode Project. 
+Open your Project's Xcode Project.
 
 Drag into "Libraries" the following files from node_modules/react-native-carnival:
 
@@ -18,6 +18,17 @@ Drag into "Libraries" the following files from node_modules/react-native-carniva
  * Carnival.framework
 
 Next, Install Carnival iOS SDK from Cocoapods (add `pod 'Carnival'` to your Podfile) or install the framework [manually](http://docs.carnival.io/docs/ios-integration#section-manual-integration).
+
+Then add a call to startEngine to the native AppDelegate.m
+
+```Objective-C
+#import <Carnival/Carnival.h>
+
+- (BOOL)application:(UIApplication * )application didFinishLaunchingWithOptions:(NSDictionary * )launchOptions {
+	[Carnival startEngine:SDK_KEY]; // Obtain SDK key from your Carnival app settings
+  return YES;
+}
+```
 
 Build and Run from Xcode.
 
@@ -53,7 +64,7 @@ dependencies {
 ```
 
 
-* Register module (in MainApplication.java)
+* Register module and call startEngine (in MainApplication.java)
 
 ```java
 import com.reactlibrary.RNCarnivalPackage; // <--- import
@@ -70,6 +81,15 @@ public class MainApplication extends Application implements ReactApplication {
     }
   ...
 
+    @Override
+    public void onCreate() {
+      super.onCreate();
+      SoLoader.init(this, /* native exopackage */ false);
+      Carnival.startEngine(getApplicationContext(), SDK_KEY); // Obtain SDK key from your Carnival app settings
+    }
+  ...
+}
+
 }
 ```
 
@@ -83,5 +103,3 @@ For push set up, follow the usual [Android Integration](https://docs.carnival.io
 ## Example
 
 We have provided an example JS file for both iOS and Android. Examples of the promises-based wrapper can be found there.
-
-

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,5 +39,11 @@ repositories {
 dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.carnival.sdk:carnival:5.+'
+
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'org.powermock:powermock:1.6.5'
+    testCompile 'org.powermock:powermock-module-junit4:1.6.5'
+    testCompile 'org.powermock:powermock-api-mockito:1.6.5'
 }
   

--- a/android/src/main/java/com/reactlibrary/RNCarnivalModule.java
+++ b/android/src/main/java/com/reactlibrary/RNCarnivalModule.java
@@ -4,6 +4,7 @@ package com.reactlibrary;
 import android.app.Activity;
 import android.content.Intent;
 import android.location.Location;
+import android.util.Log;
 
 import com.carnival.sdk.AttributeMap;
 import com.carnival.sdk.Carnival;
@@ -36,6 +37,9 @@ import java.util.Iterator;
 
 public class RNCarnivalModule extends ReactContextBaseJavaModule {
 
+  protected final static String ERROR_CODE_DEVICE = "carnival.device";
+  protected final static String ERROR_CODE_MESSAGES = "carnival.messages";
+
   private ReactApplicationContext reactApplicationContext;
   public RNCarnivalModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -48,7 +52,7 @@ public class RNCarnivalModule extends ReactContextBaseJavaModule {
     return "RNCarnival";
   }
 
-  private static void setWrapperInfo(){
+  protected static void setWrapperInfo(){
     Method setWrapperMethod = null;
     try {
       Class[] cArg = new Class[2];
@@ -91,7 +95,7 @@ public class RNCarnivalModule extends ReactContextBaseJavaModule {
 
       @Override
       public void onFailure(Error error) {
-        promise.reject("carnival.device", error.getMessage());
+        promise.reject(ERROR_CODE_DEVICE, error.getMessage());
       }
     });
   }
@@ -102,7 +106,7 @@ public class RNCarnivalModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  private void setAttributes(ReadableMap attributeMap, final Promise promise) throws JSONException {
+  public void setAttributes(ReadableMap attributeMap, final Promise promise) throws JSONException {
     JSONObject attributeMapJson = convertMapToJson(attributeMap);
     JSONObject attributes = attributeMapJson.getJSONObject("attributes");
     AttributeMap carnivalAttributeMap = new AttributeMap();
@@ -191,32 +195,37 @@ public class RNCarnivalModule extends ReactContextBaseJavaModule {
       @Override
       public void onSuccess(ArrayList<Message> messages) {
 
-        WritableArray array = new WritableNativeArray();
+        WritableArray array = getWritableArray();
         try {
           Method toJsonMethod = Message.class.getDeclaredMethod("toJSON");
           toJsonMethod.setAccessible(true);
 
           for (Message message : messages) {
             JSONObject messageJson = (JSONObject) toJsonMethod.invoke(message);
+            System.out.println(message.toString());
             array.pushMap(convertJsonToMap(messageJson));
           }
         } catch (NoSuchMethodException e) {
-          promise.reject("carnival.messages", e.getMessage());
+          promise.reject(ERROR_CODE_MESSAGES, e.getMessage());
         } catch (IllegalAccessException e) {
-          promise.reject("carnival.messages", e.getMessage());
+          promise.reject(ERROR_CODE_MESSAGES, e.getMessage());
         } catch (JSONException e) {
-          promise.reject("carnival.messages", e.getMessage());
+          promise.reject(ERROR_CODE_MESSAGES, e.getMessage());
         } catch (InvocationTargetException e) {
-          promise.reject("carnival.messages", e.getMessage());
+          promise.reject(ERROR_CODE_MESSAGES, e.getMessage());
         }
         promise.resolve(array);
       }
 
       @Override
       public void onFailure(Error error) {
-        promise.reject("carnival.messages", error.getMessage());
+        promise.reject(ERROR_CODE_MESSAGES, error.getMessage());
       }
     });
+  }
+
+  protected static WritableArray getWritableArray() {
+    return new WritableNativeArray();
   }
 
   private static WritableMap convertJsonToMap(JSONObject jsonObject) throws JSONException {
@@ -371,7 +380,7 @@ public class RNCarnivalModule extends ReactContextBaseJavaModule {
 
       @Override
       public void onFailure(Error error) {
-        promise.reject("carnival.messages", error.getMessage());
+        promise.reject(ERROR_CODE_MESSAGES, error.getMessage());
       }
     });
   }
@@ -427,7 +436,7 @@ public class RNCarnivalModule extends ReactContextBaseJavaModule {
      * Helper Methods
      */
 
-  private Message getMessage(ReadableMap messageMap) {
+  protected Message getMessage(ReadableMap messageMap) {
 
     Message message = null;
     try {

--- a/android/src/main/java/com/reactlibrary/RNCarnivalModule.java
+++ b/android/src/main/java/com/reactlibrary/RNCarnivalModule.java
@@ -40,18 +40,12 @@ public class RNCarnivalModule extends ReactContextBaseJavaModule {
   public RNCarnivalModule(ReactApplicationContext reactContext) {
     super(reactContext);
     reactApplicationContext = reactContext;
+    setWrapperInfo();
   }
 
   @Override
   public String getName() {
     return "RNCarnival";
-  }
-
-  @ReactMethod
-  public void startEngine(String appKey, boolean optInForPush) {
-    // optInForPush is not used. It's there to share signatures with iOS.
-    Carnival.startEngine(reactApplicationContext, appKey);
-    setWrapperInfo();
   }
 
   private static void setWrapperInfo(){

--- a/android/src/main/java/com/reactlibrary/RNCarnivalModule.java
+++ b/android/src/main/java/com/reactlibrary/RNCarnivalModule.java
@@ -224,6 +224,7 @@ public class RNCarnivalModule extends ReactContextBaseJavaModule {
     });
   }
 
+  // Moved out to separate method for testing as WritableNativeArray cannot be mocked
   protected static WritableArray getWritableArray() {
     return new WritableNativeArray();
   }

--- a/android/src/test/java/com/reactlibrary/RNCarnivalModuleTest.java
+++ b/android/src/test/java/com/reactlibrary/RNCarnivalModuleTest.java
@@ -1,0 +1,377 @@
+package com.reactlibrary;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.location.Location;
+
+import com.carnival.sdk.AttributeMap;
+import com.carnival.sdk.Carnival;
+import com.carnival.sdk.CarnivalImpressionType;
+import com.carnival.sdk.Message;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableArray;
+
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Carnival.class, RNCarnivalModule.class})
+public class RNCarnivalModuleTest {
+
+    @Mock
+    private ReactApplicationContext mockContext;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        PowerMockito.mockStatic(Carnival.class);
+        PowerMockito.mockStatic(RNCarnivalModule.class);
+        PowerMockito.doNothing().when(RNCarnivalModule.class, "setWrapperInfo");
+    }
+
+    @Test
+    public void testConstructor() {
+        new RNCarnivalModule(mockContext);
+
+        PowerMockito.verifyStatic();
+        RNCarnivalModule.setWrapperInfo();
+    }
+
+    @Test
+    public void testUpdateLocation() throws Exception {
+        double latitude = 10, longitude = 10;
+
+        PowerMockito.doNothing().when(Carnival.class, "updateLocation", anyObject());
+        Location location = mock(Location.class);
+        PowerMockito.whenNew(Location.class).withAnyArguments().thenReturn(location);
+        doNothing().when(location).setLatitude(anyDouble());
+        doNothing().when(location).setLongitude(anyDouble());
+
+        RNCarnivalModule rnCarnivalModule = new RNCarnivalModule(mockContext);
+        rnCarnivalModule.updateLocation(latitude, longitude);
+
+        verify(location).setLatitude(latitude);
+        verify(location).setLongitude(longitude);
+        PowerMockito.verifyStatic();
+        Carnival.updateLocation(location);
+    }
+
+    @Test
+    public void testGetDeviceID() throws Exception {
+        // Setup variables
+        String deviceID = "device ID";
+        String errorMessage = "error message";
+        Promise promise = mock(Promise.class);
+        Error error = mock(Error.class);
+
+        // Mock methods
+        PowerMockito.doNothing().when(Carnival.class, "getDeviceId", anyObject());
+        doReturn(errorMessage).when(error).getMessage();
+
+        // Start test
+        RNCarnivalModule rnCarnivalModule = new RNCarnivalModule(mockContext);
+        rnCarnivalModule.getDeviceID(promise);
+
+        // Capture handler for verification
+        ArgumentCaptor<Carnival.CarnivalHandler> argumentCaptor = ArgumentCaptor.forClass(Carnival.CarnivalHandler.class);
+        PowerMockito.verifyStatic();
+        Carnival.getDeviceId(argumentCaptor.capture());
+        Carnival.CarnivalHandler carnivalHandler = argumentCaptor.getValue();
+
+        // Test success
+        carnivalHandler.onSuccess(deviceID);
+        verify(promise).resolve(deviceID);
+
+        // Test failure
+        carnivalHandler.onFailure(error);
+        verify(promise).reject(RNCarnivalModule.ERROR_CODE_DEVICE, errorMessage);
+    }
+
+    @Test
+    public void testLogEvent() throws Exception {
+        String event = "event string";
+
+        PowerMockito.doNothing().when(Carnival.class, "logEvent", event);
+
+        RNCarnivalModule rnCarnivalModule = new RNCarnivalModule(mockContext);
+        rnCarnivalModule.logEvent(event);
+
+        PowerMockito.verifyStatic();
+        Carnival.logEvent(event);
+    }
+
+    @Test
+    public void testSetAttributes() throws Exception {
+        // setup mocks
+        ReadableMap readableMap = mock(ReadableMap.class);
+        JSONObject attributeMapJson = mock(JSONObject.class);
+        JSONObject attributeJson = mock(JSONObject.class);
+        AttributeMap attributeMap = mock(AttributeMap.class);
+        Iterator<String> keys = mock(Iterator.class);
+
+        // setup mocking for conversion from ReadableMap to JSON
+        PowerMockito.when(RNCarnivalModule.class, "convertMapToJson", readableMap).thenReturn(attributeMapJson);
+        when(attributeMapJson.getJSONObject("attributes")).thenReturn(attributeJson);
+
+        // Mock attribute map
+        PowerMockito.whenNew(AttributeMap.class).withNoArguments().thenReturn(attributeMap);
+        doNothing().when(attributeMap).setMergeRules(anyInt());
+
+        // Setup JSON objects
+        when(attributeJson.getInt("mergeRule")).thenReturn(0);
+        when(attributeJson.keys()).thenReturn(keys);
+        when(keys.hasNext()).thenReturn(false);
+
+        // Mock Carnival method
+        PowerMockito.doNothing().when(Carnival.class, "setAttributes", eq(attributeMap), any(Carnival.AttributesHandler.class));
+
+        // Initiate test
+        RNCarnivalModule rnCarnivalModule = new RNCarnivalModule(mockContext);
+        rnCarnivalModule.setAttributes(readableMap, null);
+
+        // Verify results
+        PowerMockito.verifyStatic();
+        Carnival.setAttributes(eq(attributeMap), any(Carnival.AttributesHandler.class));
+    }
+
+    @Test
+    public void testGetMessages() throws Exception {
+        // Setup mocks
+        Promise promise = mock(Promise.class);
+        WritableArray writableArray = mock(WritableArray.class);
+        Error error = mock(Error.class);
+
+        // Mock Carnival method
+        PowerMockito.doNothing().when(Carnival.class, "getMessages", any(Carnival.MessagesHandler.class));
+
+        // Initiate test
+        RNCarnivalModule rnCarnivalModule = new RNCarnivalModule(mockContext);
+        rnCarnivalModule.getMessages(promise);
+
+        // Capture MessagesHandler to verify behaviour
+        ArgumentCaptor<Carnival.MessagesHandler> argumentCaptor = ArgumentCaptor.forClass(Carnival.MessagesHandler.class);
+        PowerMockito.verifyStatic();
+        Carnival.getMessages(argumentCaptor.capture());
+        Carnival.MessagesHandler messagesHandler = argumentCaptor.getValue();
+
+        // Replace native array with mock
+        PowerMockito.when(RNCarnivalModule.class, "getWritableArray").thenReturn(writableArray);
+
+        // Setup message array
+        ArrayList<Message> messages = new ArrayList<>();
+
+        // Test success handler
+        messagesHandler.onSuccess(messages);
+        verify(promise).resolve(writableArray);
+
+        // Setup error
+        String errorMessage = "error message";
+        when(error.getMessage()).thenReturn(errorMessage);
+
+        // Test error handler
+        messagesHandler.onFailure(error);
+        verify(promise).reject(RNCarnivalModule.ERROR_CODE_MESSAGES, errorMessage);
+    }
+
+    @Test
+    public void testSetUserId() throws Exception {
+        String userID = "user ID";
+
+        PowerMockito.doNothing().when(Carnival.class, "setUserId", userID, null);
+
+        RNCarnivalModule rnCarnivalModule = new RNCarnivalModule(mockContext);
+        rnCarnivalModule.setUserId(userID);
+
+        PowerMockito.verifyStatic();
+        Carnival.setUserId(userID, null);
+    }
+
+    @Test
+    public void testSetUserEmail() throws Exception {
+        String userEmail = "user email";
+
+        PowerMockito.doNothing().when(Carnival.class, "setUserEmail", userEmail, null);
+
+        RNCarnivalModule rnCarnivalModule = new RNCarnivalModule(mockContext);
+        rnCarnivalModule.setUserEmail(userEmail);
+
+        PowerMockito.verifyStatic();
+        Carnival.setUserEmail(userEmail, null);
+    }
+
+    @Test
+    public void testGetUnreadCount() throws Exception {
+        int unreadCount = 4;
+        Promise promise = mock(Promise.class);
+
+        PowerMockito.when(Carnival.class, "getUnreadMessageCount").thenReturn(unreadCount);
+
+        RNCarnivalModule rnCarnivalModule = new RNCarnivalModule(mockContext);
+        rnCarnivalModule.getUnreadCount(promise);
+
+        PowerMockito.verifyStatic();
+        Carnival.getUnreadMessageCount();
+
+        verify(promise).resolve(unreadCount);
+    }
+
+    @Test
+    public void testRemoveMessage() throws Exception {
+        // Create mocks
+        ReadableMap readableMap = mock(ReadableMap.class);
+
+        // Create message to remove
+        RNCarnivalModule rnCarnivalModule = spy(new RNCarnivalModule(mockContext));
+        Constructor<Message> constructor = Message.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Message message = constructor.newInstance();
+        doReturn(message).when(rnCarnivalModule).getMessage(readableMap);
+
+        // Mock Carnival method
+        PowerMockito.doNothing().when(Carnival.class, "deleteMessage", message, null);
+
+        // Initiate test
+        rnCarnivalModule.removeMessage(readableMap);
+
+        // Verify result
+        PowerMockito.verifyStatic();
+        Carnival.deleteMessage(message, null);
+    }
+
+    @Test
+    public void testRegisterMessageImpression() throws Exception {
+        // Create input
+        ReadableMap readableMap = mock(ReadableMap.class);
+        int typeCode = 0;
+
+        // Create message to remove
+        RNCarnivalModule rnCarnivalModule = spy(new RNCarnivalModule(mockContext));
+        Constructor<Message> constructor = Message.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Message message = constructor.newInstance();
+        doReturn(message).when(rnCarnivalModule).getMessage(readableMap);
+
+        // Mock Carnival method
+        PowerMockito.doNothing().when(Carnival.class, "registerMessageImpression", CarnivalImpressionType.IMPRESSION_TYPE_IN_APP_VIEW, message);
+
+        // Initiate test
+        rnCarnivalModule.registerMessageImpression(typeCode, readableMap);
+
+        // Verify result
+        PowerMockito.verifyStatic();
+        Carnival.registerMessageImpression(CarnivalImpressionType.IMPRESSION_TYPE_IN_APP_VIEW, message);
+    }
+
+    @Test
+    public void testMarkMessageAsRead() throws Exception {
+        // Create mocks
+        ReadableMap readableMap = mock(ReadableMap.class);
+        Promise promise = mock(Promise.class);
+
+        // Create message to remove
+        RNCarnivalModule rnCarnivalModule = spy(new RNCarnivalModule(mockContext));
+        Constructor<Message> constructor = Message.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Message message = constructor.newInstance();
+        doReturn(message).when(rnCarnivalModule).getMessage(readableMap);
+
+        // Mock Carnival method
+        PowerMockito.doNothing().when(Carnival.class, "setMessageRead", eq(message), any(Carnival.MessagesReadHandler.class));
+
+        // Initiate test
+        rnCarnivalModule.markMessageAsRead(readableMap, promise);
+
+        // Verify result
+        PowerMockito.verifyStatic();
+        Carnival.setMessageRead(eq(message), any(Carnival.MessagesReadHandler.class));
+    }
+
+    @Test
+    public void testSetDisplayInAppNotificationsTrue() throws Exception {
+        // Mock Carnival method
+        PowerMockito.doNothing().when(Carnival.class, "setOnInAppNotificationDisplayListener", any(Carnival.OnInAppNotificationDisplayListener.class));
+
+        // Initiate true test
+        RNCarnivalModule rnCarnivalModule = new RNCarnivalModule(mockContext);
+        rnCarnivalModule.setDisplayInAppNotifications(true);
+
+        // Capture listener to verify behaviour
+        ArgumentCaptor<Carnival.OnInAppNotificationDisplayListener> argumentCaptor = ArgumentCaptor.forClass(Carnival.OnInAppNotificationDisplayListener.class);
+        PowerMockito.verifyStatic();
+        Carnival.setOnInAppNotificationDisplayListener(argumentCaptor.capture());
+        Carnival.OnInAppNotificationDisplayListener listener = argumentCaptor.getValue();
+
+        // Verify result
+        assertNull(listener);
+    }
+
+    @Test
+    public void testSetDisplayInAppNotificationsFalse() throws Exception {
+        // Mock Carnival method
+        PowerMockito.doNothing().when(Carnival.class, "setOnInAppNotificationDisplayListener", any(Carnival.OnInAppNotificationDisplayListener.class));
+
+        // Initiate true test
+        RNCarnivalModule rnCarnivalModule = new RNCarnivalModule(mockContext);
+        rnCarnivalModule.setDisplayInAppNotifications(false);
+
+        // Capture listener to verify behaviour
+        ArgumentCaptor<Carnival.OnInAppNotificationDisplayListener> argumentCaptor = ArgumentCaptor.forClass(Carnival.OnInAppNotificationDisplayListener.class);
+        PowerMockito.verifyStatic();
+        Carnival.setOnInAppNotificationDisplayListener(argumentCaptor.capture());
+        Carnival.OnInAppNotificationDisplayListener listener = argumentCaptor.getValue();
+
+        // Verify result
+        assertNotNull(listener);
+    }
+
+    @Test
+    public void testPresentMessageDetail() throws Exception {
+        // Setup input
+        String messageID = "message ID";
+
+        // Mock activity
+        Activity activity = mock(Activity.class);
+        when(mockContext.getCurrentActivity()).thenReturn(activity);
+
+        // Mock Intent
+        Intent intent = mock(Intent.class);
+        PowerMockito.whenNew(Intent.class).withAnyArguments().thenReturn(intent);
+        doReturn(intent).when(intent).putExtra(Carnival.EXTRA_MESSAGE_ID, messageID);
+
+        // Initiate test
+        RNCarnivalModule rnCarnivalModule = new RNCarnivalModule(mockContext);
+        rnCarnivalModule.presentMessageDetail(messageID);
+
+        // Verify result
+        verify(activity).startActivity(intent);
+    }
+
+}


### PR DESCRIPTION
It has been determined that the missing session open events in Android RN apps is a result of the RN components calling startEngine too late in the loading process. The main activity is already started before the RN components are loaded. In order to prevent this, future guidance for the RN wrapper will be to call startEngine when the native application is created (same as for native SDKs).

As a result, startEngine in RN is being removed (removed in iOS here:https://github.com/carnivalmobile/carnival-sdk-react-native/pull/8) and the setWrapper method is being moved to the RNCarnivalModule constructor.
