### PR TITLE
Update native SDK versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ repositories {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api 'com.carnival.sdk:carnival:6.1.0'
+    api 'com.carnival.sdk:carnival:6.2.1'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:1.10.19'
@@ -45,4 +45,3 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4:1.6.5'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.5'
 }
-  

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -16,7 +16,7 @@ target 'CarnivalSDKReactNative' do
       'CxxBridge' # Include this for RN >= 0.47
     ]
 
-    pod 'Carnival', '7.4.0'
+    pod 'Carnival', '7.6.0'
     pod 'Kiwi', '2.4.0'
     pod 'OCMock', '3.1.2'
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost-for-react-native (1.63.0)
-  - Carnival (7.4.0)
+  - Carnival (7.6.0)
   - DoubleConversion (1.1.5)
   - Folly (2016.10.31.00):
     - boost-for-react-native
@@ -28,7 +28,7 @@ PODS:
   - yoga (0.56.0.React)
 
 DEPENDENCIES:
-  - Carnival (= 7.4.0)
+  - Carnival (= 7.6.0)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - Kiwi (= 2.4.0)
   - OCMock (= 3.1.2)
@@ -55,7 +55,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  Carnival: d2ab8552356eecd22044116ebbd4ef0407796925
+  Carnival: d1863e4010e9f728f6aa7a94ac2f52bc50964465
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   Folly: c89ac2d5c6ab169cd7397ef27485c44f35f742c7
   glog: 1de0bb937dccdc981596d3b5825ebfb765017ded
@@ -64,6 +64,6 @@ SPEC CHECKSUMS:
   React: 1fe0eb13d90b625d94c3b117c274dcfd2e760e11
   yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
 
-PODFILE CHECKSUM: 09940d6fa7bedbf2b9d626fd23cd2a97092e2c4c
+PODFILE CHECKSUM: be972b23e7237cd55a65b404d0607dda3a581ec0
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Update native SDK version that include universal links handling. The latest Android SDK includes universal links handling so this functionality can now be used by the React Native SDK.