### PR TITLE
Remove unwanted files from npm package

### DIFF
--- a/ios/.npmignore
+++ b/ios/.npmignore
@@ -1,0 +1,3 @@
+# OS X
+# Sometimes these are hiding in the iOS frameworks
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -32,5 +32,13 @@
   "version": "3.3.0",
   "devDependencies": {
     "react-native": "^0.56.0"
-  }
+  },
+  "files": [
+    "/ios/Carnival.framework",
+    "/ios/CarnivalExtension.framework",
+    "/ios/RNCarnival*",
+    "/android/src/main",
+    "/android/build.gradle",
+    "/example"
+  ]
 }


### PR DESCRIPTION
The published npm package is currently pretty bloated with a lot of git/build/test files that it doesn't need and some of which can cause errors: https://github.com/carnivalmobile/carnival-sdk-react-native/issues/38. This change will remove all the unnecessary files from the published package.