### PR TITLE
Repackage Android classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ dependencies {
 * Register module (in MainApplication.java)
 
 ```java
-import com.reactlibrary.RNSailthruMobilePackage; // <--- import
+import com.sailthru.mobile.rnsdk.RNSailthruMobilePackage; // <--- import
 
 public class MainApplication extends Application implements ReactApplication {
   ...

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.sailthru.mobile.rnsdk">
 
 </manifest>
   

--- a/android/src/main/java/com/sailthru/mobile/rnsdk/RNCarnivalPackage.java
+++ b/android/src/main/java/com/sailthru/mobile/rnsdk/RNCarnivalPackage.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary;
+package com.sailthru.mobile.rnsdk;
 
 import android.content.Context;
 
@@ -16,7 +16,7 @@ import java.util.List;
 
 /**
  * React native package for the Carnival SDK.
- * @deprecated use {@link com.reactlibrary.RNSailthruMobilePackage}
+ * @deprecated use {@link RNSailthruMobilePackage}
  */
 public class RNCarnivalPackage implements ReactPackage {
     protected ReactApplicationContext reactApplicationContext;

--- a/android/src/main/java/com/sailthru/mobile/rnsdk/RNSailthruMobilePackage.java
+++ b/android/src/main/java/com/sailthru/mobile/rnsdk/RNSailthruMobilePackage.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary;
+package com.sailthru.mobile.rnsdk;
 
 import android.content.Context;
 

--- a/android/src/test/java/com/sailthru/mobile/rnsdk/RNCarnivalModuleTest.java
+++ b/android/src/test/java/com/sailthru/mobile/rnsdk/RNCarnivalModuleTest.java
@@ -1,4 +1,4 @@
-package com.reactlibrary;
+package com.sailthru.mobile.rnsdk;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -16,6 +16,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.sailthru.mobile.rnsdk.RNCarnivalModule;
 
 import org.json.JSONObject;
 import org.junit.Before;

--- a/android/src/test/java/com/sailthru/mobile/rnsdk/RNCarnivalPackageTest.java
+++ b/android/src/test/java/com/sailthru/mobile/rnsdk/RNCarnivalPackageTest.java
@@ -1,4 +1,4 @@
-package com.reactlibrary;
+package com.sailthru.mobile.rnsdk;
 
 import android.content.Context;
 
@@ -6,6 +6,8 @@ import com.carnival.sdk.Carnival;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.sailthru.mobile.rnsdk.RNCarnivalModule;
+import com.sailthru.mobile.rnsdk.RNCarnivalPackage;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/android/src/test/java/com/sailthru/mobile/rnsdk/RNSailthruMobileModuleTest.java
+++ b/android/src/test/java/com/sailthru/mobile/rnsdk/RNSailthruMobileModuleTest.java
@@ -1,9 +1,10 @@
-package com.reactlibrary;
+package com.sailthru.mobile.rnsdk;
 
 import android.app.Activity;
 import android.content.Intent;
 import android.location.Location;
 
+import com.sailthru.mobile.rnsdk.RNSailthruMobileModule;
 import com.sailthru.mobile.sdk.MessageActivity;
 import com.sailthru.mobile.sdk.MessageStream;
 import com.sailthru.mobile.sdk.model.AttributeMap;

--- a/android/src/test/java/com/sailthru/mobile/rnsdk/RNSailthruMobilePackageTest.java
+++ b/android/src/test/java/com/sailthru/mobile/rnsdk/RNSailthruMobilePackageTest.java
@@ -1,10 +1,12 @@
-package com.reactlibrary;
+package com.sailthru.mobile.rnsdk;
 
 import android.content.Context;
 
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.sailthru.mobile.rnsdk.RNSailthruMobileModule;
+import com.sailthru.mobile.rnsdk.RNSailthruMobilePackage;
 import com.sailthru.mobile.sdk.SailthruMobile;
 
 import org.junit.Assert;


### PR DESCRIPTION
This PR moves the android classes from the default package `com.reactlibrary` to a more relevant package structure: `com.sailthru.mobile.rnsdk`. This will avoid clashes with other libraries that have also kept the default package. Resolves issue #51