### PR TITLE
fix: Update build tools and remove option causing error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,13 +1,13 @@
 
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = '1.6.21'
     repositories {
         mavenCentral()
         google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -16,12 +16,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 31
-    buildToolsVersion '30.0.3'
+    compileSdk 32
+    buildToolsVersion '32.0.0'
 
     defaultConfig {
         minSdk 21
-        targetSdk 31
+        targetSdk 32
     }
     testOptions {
         unitTests {
@@ -33,9 +33,6 @@ android {
                 }
             }
         }
-    }
-    lint {
-        abortOnError false
     }
 }
 
@@ -64,6 +61,6 @@ dependencies {
     testImplementation 'org.powermock:powermock-core:2.0.2'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.2'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.2'
-    testImplementation 'org.json:json:20210307'
+    testImplementation 'org.json:json:20220320'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Aug 30 16:27:56 NZST 2018
+#Fri Jul 22 16:00:40 BST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/android/src/test/java/com/sailthru/mobile/rnsdk/JsonConverterTest.kt
+++ b/android/src/test/java/com/sailthru/mobile/rnsdk/JsonConverterTest.kt
@@ -181,7 +181,7 @@ class JsonConverterTest {
 
         val writableArray = jsonConverter.convertJsonToArray(jsonArray)
 
-        assertEquals("thing", writableArray.getMap(0)?.getString("some"))
+        assertEquals("thing", writableArray.getMap(0).getString("some"))
     }
 
     @Test
@@ -195,7 +195,7 @@ class JsonConverterTest {
 
         val writableArray = jsonConverter.convertJsonToArray(jsonArray)
 
-        assertEquals("inner string", writableArray.getArray(0)?.getString(0))
+        assertEquals("inner string", writableArray.getArray(0).getString(0))
     }
 
     @Test
@@ -221,8 +221,8 @@ class JsonConverterTest {
         assertEquals(123, writableArray.getInt(1))
         assertEquals(1.23, writableArray.getDouble(2), 0.001)
         assertEquals("test string", writableArray.getString(3))
-        assertEquals("thing", writableArray.getMap(4)?.getString("some"))
-        assertEquals("inner string", writableArray.getArray(5)?.getString(0))
+        assertEquals("thing", writableArray.getMap(4).getString("some"))
+        assertEquals("inner string", writableArray.getArray(5).getString(0))
     }
 
 

--- a/android/src/test/java/com/sailthru/mobile/rnsdk/RNSailthruMobileModuleTest.java
+++ b/android/src/test/java/com/sailthru/mobile/rnsdk/RNSailthruMobileModuleTest.java
@@ -41,10 +41,10 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
This PR updates the Android build tools and removes the lint options block, as this causes a rather obtuse error in gradle when built with build tools version 31 and above.