### PR TITLE
test: Remove Powermock dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,10 +57,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlin_version"
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:3.10.0'
-    testImplementation 'org.powermock:powermock-core:2.0.2'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.2'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.2'
+    testImplementation 'org.mockito:mockito-inline:4.1.0'
     testImplementation 'org.json:json:20220320'
-    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
 }

--- a/android/src/test/java/com/sailthru/mobile/rnsdk/JsonConverterTest.kt
+++ b/android/src/test/java/com/sailthru/mobile/rnsdk/JsonConverterTest.kt
@@ -1,8 +1,6 @@
 package com.sailthru.mobile.rnsdk
 
 import com.facebook.react.bridge.*
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.spy
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.*
@@ -10,6 +8,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.BlockJUnit4ClassRunner
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.spy
 
 @RunWith(BlockJUnit4ClassRunner::class)
 class JsonConverterTest {

--- a/android/src/test/java/com/sailthru/mobile/rnsdk/RNSailthruMobilePackageTest.java
+++ b/android/src/test/java/com/sailthru/mobile/rnsdk/RNSailthruMobilePackageTest.java
@@ -12,25 +12,24 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.List;
 
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({RNSailthruMobilePackage.class, RNSailthruMobileModule.class})
+@RunWith(MockitoJUnitRunner.class)
 public class RNSailthruMobilePackageTest {
-
     @Mock
     private Context mockContext;
     @Mock
     private ReactApplicationContext reactApplicationContext;
     @Mock
+    private MockedConstruction<RNSailthruMobileModule> staticRnSailthruMobileModule;
+    @Mock
+    private MockedConstruction<SailthruMobile> staticSailthruMobile;
+
     private SailthruMobile sailthruMobile;
 
     private final String appKey = "App Key";
@@ -39,13 +38,12 @@ public class RNSailthruMobilePackageTest {
     private RNSailthruMobilePackage rnSTPackage;
 
     @Before
-    public void setup() throws Exception {
-        MockitoAnnotations.openMocks(this);
-        PowerMockito.whenNew(SailthruMobile.class).withAnyArguments().thenReturn(sailthruMobile);
-
+    public void setup() {
         builder = RNSailthruMobilePackage.Builder.createInstance(mockContext, appKey).setDisplayInAppNotifications(false).setGeoIPTrackingDefault(false);
 
         rnSTPackage = new RNSailthruMobilePackage(mockContext, appKey);
+
+        sailthruMobile = staticSailthruMobile.constructed().get(0);
     }
 
     @Test
@@ -55,8 +53,8 @@ public class RNSailthruMobilePackageTest {
 
     @Test
     public void testBuilderConstructor() {
-        reset(sailthruMobile);
         RNSailthruMobilePackage rnSTPackageFromBuilderConstructor = new RNSailthruMobilePackage(builder);
+        sailthruMobile = staticSailthruMobile.constructed().get(1);
         verify(sailthruMobile).startEngine(mockContext, appKey);
         verify(sailthruMobile).setGeoIpTrackingDefault(false);
         verify(sailthruMobile).setGeoIpTrackingDefault(false);
@@ -64,13 +62,11 @@ public class RNSailthruMobilePackageTest {
     }
 
     @Test
-    public void testCreateNativeModules() throws Exception {
-        RNSailthruMobileModule rnSailthruMobileModule = PowerMockito.mock(RNSailthruMobileModule.class);
-        PowerMockito.whenNew(RNSailthruMobileModule.class).withAnyArguments().thenReturn(rnSailthruMobileModule);
+    public void testCreateNativeModules() {
         List<NativeModule> nativeModules = rnSTPackage.createNativeModules(reactApplicationContext);
         Assert.assertEquals(1, nativeModules.size());
         NativeModule nativeModule = nativeModules.get(0);
-        Assert.assertEquals(rnSailthruMobileModule, nativeModule);
+        Assert.assertEquals(staticRnSailthruMobileModule.constructed().get(0), nativeModule);
     }
 
     @Test
@@ -112,8 +108,8 @@ public class RNSailthruMobilePackageTest {
 
     @Test
     public void testBuilderBuild() {
-        reset(sailthruMobile);
         RNSailthruMobilePackage rnSTPackageFromBuilderBuild = builder.build();
+        sailthruMobile = staticSailthruMobile.constructed().get(1);
         verify(sailthruMobile).startEngine(mockContext, appKey);
         verify(sailthruMobile).setGeoIpTrackingDefault(false);
         Assert.assertFalse(rnSTPackageFromBuilderBuild.displayInAppNotifications);


### PR DESCRIPTION
This PR:
* Removes the Powermock test dependency and migrates static mocking to Mockito's implementation
* Upgrades Mockito dependency version (was previously blocked by a conflict with Powermock)