### PR TITLE
Fix duplicate method name conflict in Kotlin module for new RN architecture

### DIFF
--- a/android/src/main/java/com/marigold/rnsdk/RNEngageBySailthruModule.kt
+++ b/android/src/main/java/com/marigold/rnsdk/RNEngageBySailthruModule.kt
@@ -38,7 +38,7 @@ class RNEngageBySailthruModule (reactContext: ReactApplicationContext) : ReactCo
     }
 
     @ReactMethod
-    fun logEvent(eventName: String, varsMap: ReadableMap) {
+    fun logEventWithVars(eventName: String, varsMap: ReadableMap) {
         var varsJson: JSONObject? = null
         try {
             varsJson = jsonConverter.convertMapToJson(varsMap)

--- a/android/src/main/java/com/marigold/rnsdk/RNMarigoldModule.kt
+++ b/android/src/main/java/com/marigold/rnsdk/RNMarigoldModule.kt
@@ -110,11 +110,12 @@ class RNMarigoldModule(reactContext: ReactApplicationContext) : ReactContextBase
     @ReactMethod
     fun setGeoIPTrackingEnabledWithPromise(enabled: Boolean, promise: Promise) {
         marigold.setGeoIpTrackingEnabled(enabled, object : Marigold.MarigoldHandler<Void?> {
-            override fun onComplete(result: Void?) {
-                promise.resolve(null)
+            override fun onSuccess(value: Void?) {
+                promise.resolve(true)
             }
-            override fun onError(error: Throwable) {
-                promise.reject("ERROR", error)
+
+            override fun onFailure(error: Error) {
+                promise.reject(ERROR_CODE_DEVICE, error.message)
             }
         })
     }

--- a/android/src/main/java/com/marigold/rnsdk/RNMarigoldModule.kt
+++ b/android/src/main/java/com/marigold/rnsdk/RNMarigoldModule.kt
@@ -108,14 +108,13 @@ class RNMarigoldModule(reactContext: ReactApplicationContext) : ReactContextBase
     }
 
     @ReactMethod
-    fun setGeoIPTrackingEnabled(enabled: Boolean, promise: Promise) {
+    fun setGeoIPTrackingEnabledWithPromise(enabled: Boolean, promise: Promise) {
         marigold.setGeoIpTrackingEnabled(enabled, object : Marigold.MarigoldHandler<Void?> {
-            override fun onSuccess(value: Void?) {
-                promise.resolve(true)
+            override fun onComplete(result: Void?) {
+                promise.resolve(null)
             }
-
-            override fun onFailure(error: Error) {
-                promise.reject(ERROR_CODE_DEVICE, error.message)
+            override fun onError(error: Throwable) {
+                promise.reject("ERROR", error)
             }
         })
     }

--- a/android/src/test/java/com/marigold/rnsdk/RNMarigoldModuleTest.kt
+++ b/android/src/test/java/com/marigold/rnsdk/RNMarigoldModuleTest.kt
@@ -152,7 +152,7 @@ class RNMarigoldModuleTest {
         val error: Error = mock()
 
         // Initiate test
-        rnMarigoldModule.setGeoIPTrackingEnabled(false, promise)
+        rnMarigoldModule.setGeoIPTrackingEnabledWithPromise(false, promise)
 
         // Verify result
         verify(marigold).setGeoIpTrackingEnabled(eq(false), capture(marigoldVoidCaptor))

--- a/example/app.js
+++ b/example/app.js
@@ -61,7 +61,7 @@ export default class App extends Component {
     var eventVars = {
       "varKey" : "varValue"
     };
-    EngageBySailthru.logEvent("this is my event with vars", eventVars);
+    EngageBySailthru.logEventWithVars("this is my event with vars", eventVars);
 
     MessageStream.getUnreadCount().then(function(count) {
       console.log(count);

--- a/example/index.android.js
+++ b/example/index.android.js
@@ -60,7 +60,7 @@ class ReactNativeSampleApp extends Component {
       var eventVars = {
         "varKey" : "varValue"
       };
-      EngageBySailthru.logEvent("this is my event with vars", eventVars);
+      EngageBySailthru.logEventWithVars("this is my event with vars", eventVars);
 
       MessageStream.getUnreadCount().then(function(count) {
         console.log(count);

--- a/example/index.ios.js
+++ b/example/index.ios.js
@@ -61,7 +61,7 @@ export default class ReactNativeSampleApp extends Component {
     var eventVars = {
       "varKey" : "varValue"
     };
-    EngageBySailthru.logEvent("this is my event with vars", eventVars);
+    EngageBySailthru.logEventWithVars("this is my event with vars", eventVars);
 
     MessageStream.getUnreadCount().then(function(count) {
       console.log(count);

--- a/ios/MarigoldSDKReactNativeTests/RNEngageBySailthruTests.m
+++ b/ios/MarigoldSDKReactNativeTests/RNEngageBySailthruTests.m
@@ -12,7 +12,7 @@
 -(void)removeAttribute:(NSString *)key resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 -(void)clearAttributes:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 -(void)logEvent:(NSString *)name;
--(void)logEvent:(NSString *)name withVars:(NSDictionary*)varsDict;
+-(void)logEventWithVars:(NSString *)name vars:(NSDictionary*)varsDict;
 -(void)setUserId:(NSString *)userID resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 -(void)setUserEmail:(NSString *)userEmail resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 -(void)trackClick:(NSString *)sectionID url:(NSString *)url resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
@@ -267,13 +267,13 @@ describe(@"RNEngageBySailthru", ^{
         });
     });
     
-    context(@"the logEvent:withVars method", ^{
+    context(@"the logEventWithVars:vars: method", ^{
         it(@"should call native method", ^{
             NSString *event = @"Test Event";
             NSDictionary* eventVars = @{ @"varKey" : @"varValue" };
             [[engageBySailthru should] receive:@selector(logEvent:withVars:) withArguments:event, eventVars];
             
-            [rnEngageBySailthru logEvent:event withVars:eventVars];
+            [rnEngageBySailthru logEventWithVars:event vars:eventVars];
         });
     });
     

--- a/ios/MarigoldSDKReactNativeTests/RNMarigoldTests.m
+++ b/ios/MarigoldSDKReactNativeTests/RNMarigoldTests.m
@@ -13,7 +13,7 @@
 -(void)updateLocation:(CGFloat)lat lon:(CGFloat)lon;
 -(void)getDeviceID:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 -(void)setGeoIPTrackingEnabled:(BOOL)enabled;
--(void)setGeoIPTrackingEnabled:(BOOL)enabled resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
+-(void)setGeoIPTrackingEnabledWithPromise:(BOOL)enabled resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject;
 -(void)setGeoIPTrackingDefault:(BOOL)enabled;
 -(void)setCrashHandlersEnabled:(BOOL)enabled;
 -(void)logRegistrationEvent:(NSString * _Nullable)userId;
@@ -142,11 +142,11 @@ describe(@"RNMarigold", ^{
         });
     });
     
-    context(@"the setGeoIPTrackingEnabled:resolver:rejecter: method", ^{
+    context(@"the setGeoIPTrackingEnabledWithPromise:resolver:rejecter: method", ^{
         it(@"should call native method", ^{
             [[marigold should] receive:@selector(setGeoIPTrackingEnabled:withResponse:) withArguments:theValue(YES), any(), any()];
             
-            [rnMarigold setGeoIPTrackingEnabled:YES resolver:nil rejecter:nil];
+            [rnMarigold setGeoIPTrackingEnabledWithPromise:YES resolver:nil rejecter:nil];
         });
         
         it(@"should return success", ^{
@@ -158,7 +158,7 @@ describe(@"RNMarigold", ^{
             KWCaptureSpy *capture = [marigold captureArgument:@selector(setGeoIPTrackingEnabled:withResponse:) atIndex:1];
             
             // Start test
-            [rnMarigold setGeoIPTrackingEnabled:YES resolver:resolve rejecter:nil];
+            [rnMarigold setGeoIPTrackingEnabledWithPromise:YES resolver:resolve rejecter:nil];
             
             // Capture argument
             void (^completeBlock)(NSError * _Nullable) = capture.argument;
@@ -177,7 +177,7 @@ describe(@"RNMarigold", ^{
             KWCaptureSpy *capture = [marigold captureArgument:@selector(setGeoIPTrackingEnabled:withResponse:) atIndex:1];
             
             // Start test
-            [rnMarigold setGeoIPTrackingEnabled:YES resolver:nil rejecter:reject];
+            [rnMarigold setGeoIPTrackingEnabledWithPromise:YES resolver:nil rejecter:reject];
             
             // Capture argument
             void (^completeBlock)(NSError * _Nullable) = capture.argument;

--- a/ios/RNEngageBySailthru.m
+++ b/ios/RNEngageBySailthru.m
@@ -141,7 +141,7 @@ RCT_EXPORT_METHOD(logEvent:(NSString *)name) {
     [[self engageBySailthruWithRejecter:nil] logEvent:name];
 }
 
-RCT_EXPORT_METHOD(logEvent:(NSString *)name withVars:(NSDictionary*)varsDict) {
+RCT_EXPORT_METHOD(logEventWithVars:(NSString *)name vars:(NSDictionary*)varsDict) {
     [[self engageBySailthruWithRejecter:nil] logEvent:name withVars:varsDict];
 }
 

--- a/ios/RNMarigold.m
+++ b/ios/RNMarigold.m
@@ -71,7 +71,7 @@ RCT_EXPORT_METHOD(setGeoIPTrackingEnabled:(BOOL)enabled) {
     [self.marigold setGeoIPTrackingEnabled:enabled];
 }
 
-RCT_EXPORT_METHOD(setGeoIPTrackingEnabled:(BOOL)enabled resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(setGeoIPTrackingEnabledWithPromise:(BOOL)enabled resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     [self.marigold setGeoIPTrackingEnabled:enabled withResponse:^(NSError * _Nullable error) {
         if (error) {
             [RNMarigold rejectPromise:reject withError:error];


### PR DESCRIPTION
**Summary:**
This PR resolves TurboModule compatibility issues with React Native 0.72+ by renaming all overloaded native methods to have unique names. This prevents runtime crashes caused by duplicate method names in the new architecture.

**Details:**
Renamed all overloaded native methods (e.g., logEvent(eventName, vars) → logEventWithVars(eventName, vars), setGeoIPTrackingEnabled(enabled, promise) → setGeoIPTrackingEnabledWithPromise(enabled, promise), etc.) on both Android and iOS.

Updated all JS usage and examples to use the new method names.

No functional changes: the renamed methods work exactly as before, just with unique names to satisfy TurboModule requirements.

This change is required for compatibility with React Native 0.72+ and Expo SDK 53+.

Why:
React Native’s new TurboModule system does not allow multiple native methods with the same name, even if their parameters differ. This PR ensures the SDK works with the latest React Native versions and avoids runtime crashes.

Impact:

- No breaking changes for single-argument methods.
- For methods that previously accepted multiple signatures (e.g., logEvent with and without parameters), JS code using the two-argument version must now use the new method name (e.g., logEventWithVars).