### PR TITLE
[MP-2283] Add getMessage method

### DIFF
--- a/android/src/main/java/com/marigold/rnsdk/RNMarigoldModuleImpl.kt
+++ b/android/src/main/java/com/marigold/rnsdk/RNMarigoldModuleImpl.kt
@@ -28,7 +28,7 @@ class RNMarigoldModuleImpl(private val reactContext: ReactApplicationContext) {
                 val setWrapperMethod = companionClass.getDeclaredMethod("setWrapper", *cArg)
 
                 setWrapperMethod.isAccessible = true
-                setWrapperMethod.invoke(Marigold.Companion, "React Native", "16.0.0")
+                setWrapperMethod.invoke(Marigold.Companion, "React Native", "16.1.0")
             } catch (e: NoSuchMethodException) {
                 e.printStackTrace()
             } catch (e: IllegalAccessException) {

--- a/android/src/main/java/com/marigold/rnsdk/RNMarigoldModuleImpl.kt
+++ b/android/src/main/java/com/marigold/rnsdk/RNMarigoldModuleImpl.kt
@@ -4,13 +4,14 @@ import android.app.Activity
 import android.location.Location
 import androidx.annotation.VisibleForTesting
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
 import com.marigold.sdk.Marigold
 import java.lang.reflect.InvocationTargetException
 
 /**
  * React native module for the Marigold SDK.
  */
-class RNMarigoldModuleImpl {
+class RNMarigoldModuleImpl(private val reactContext: ReactApplicationContext) {
 
     companion object {
         const val ERROR_CODE_DEVICE = "marigold.device"
@@ -45,8 +46,8 @@ class RNMarigoldModuleImpl {
         setWrapperInfo()
     }
 
-    fun registerForPushNotifications(activity: Activity?) {
-        activity ?: return
+    fun registerForPushNotifications() {
+        val activity = reactContext.currentActivity ?: return
         marigold.requestNotificationPermission(activity)
     }
 

--- a/android/src/main/java/com/marigold/rnsdk/RNMessageStreamModuleImpl.kt
+++ b/android/src/main/java/com/marigold/rnsdk/RNMessageStreamModuleImpl.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import androidx.annotation.VisibleForTesting
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
@@ -20,6 +21,7 @@ import org.json.JSONObject
 import java.lang.reflect.InvocationTargetException
 
 class RNMessageStreamModuleImpl (
+    private val reactContext: ReactApplicationContext,
     displayInAppNotifications: Boolean,
     @get:VisibleForTesting internal val inAppNotificationEmitter: InAppNotificationEmitter
 ) : MessageStream.OnInAppNotificationDisplayListener  {
@@ -202,9 +204,9 @@ class RNMessageStreamModuleImpl (
         })
     }
 
-    fun presentMessageDetail(message: ReadableMap?, activity: Activity?) {
+    fun presentMessageDetail(message: ReadableMap?) {
         message ?: return
-        activity ?: return
+        val activity = reactContext.currentActivity ?: return
         val messageId = message.getString(RNMarigoldModuleImpl.MESSAGE_ID)
         if (messageId == null) return
         val i = getMessageActivityIntent(activity, messageId)

--- a/android/src/newarch/com/marigold/rnsdk/RNMarigoldModule.kt
+++ b/android/src/newarch/com/marigold/rnsdk/RNMarigoldModule.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 
 class RNMarigoldModule(reactContext: ReactApplicationContext) : NativeRNMarigoldSpec(reactContext) {
-    private val rnMarigoldModuleImpl = RNMarigoldModuleImpl()
+    private val rnMarigoldModuleImpl = RNMarigoldModuleImpl(reactContext)
 
     override fun getName(): String {
         return RNMarigoldModuleImpl.NAME
@@ -31,7 +31,7 @@ class RNMarigoldModule(reactContext: ReactApplicationContext) : NativeRNMarigold
     }
 
     override fun registerForPushNotifications() {
-        rnMarigoldModuleImpl.registerForPushNotifications(currentActivity)
+        rnMarigoldModuleImpl.registerForPushNotifications()
     }
 
     override fun syncNotificationSettings() {

--- a/android/src/newarch/com/marigold/rnsdk/RNMessageStreamModule.kt
+++ b/android/src/newarch/com/marigold/rnsdk/RNMessageStreamModule.kt
@@ -25,6 +25,10 @@ class RNMessageStreamModule(private val reactContext: ReactApplicationContext, d
         rnMessageStreamModuleImpl.useDefaultInAppNotification(useDefault)
     }
 
+    override fun getMessage(messageId: String, promise: Promise?) {
+        rnMessageStreamModuleImpl.getMessage(messageId, promise)
+    }
+
     override fun getMessages(promise: Promise?) {
         rnMessageStreamModuleImpl.getMessages(promise)
     }

--- a/android/src/newarch/com/marigold/rnsdk/RNMessageStreamModule.kt
+++ b/android/src/newarch/com/marigold/rnsdk/RNMessageStreamModule.kt
@@ -11,7 +11,7 @@ class RNMessageStreamModule(private val reactContext: ReactApplicationContext, d
     }
 
     @VisibleForTesting
-    internal var rnMessageStreamModuleImpl = RNMessageStreamModuleImpl(displayInAppNotifications, inAppNotificationEmitter)
+    internal var rnMessageStreamModuleImpl = RNMessageStreamModuleImpl(reactContext, displayInAppNotifications, inAppNotificationEmitter)
 
     override fun getName(): String {
         return RNMessageStreamModuleImpl.NAME
@@ -46,7 +46,7 @@ class RNMessageStreamModule(private val reactContext: ReactApplicationContext, d
     }
 
     override fun presentMessageDetail(message: ReadableMap?) {
-        rnMessageStreamModuleImpl.presentMessageDetail(message, reactContext.currentActivity)
+        rnMessageStreamModuleImpl.presentMessageDetail(message)
     }
 
     override fun dismissMessageDetail() {

--- a/android/src/oldarch/com/marigold/rnsdk/RNMarigoldModule.kt
+++ b/android/src/oldarch/com/marigold/rnsdk/RNMarigoldModule.kt
@@ -13,8 +13,8 @@ import java.lang.reflect.InvocationTargetException
 /**
  * React native module for the Marigold SDK.
  */
-class RNMarigoldModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
-    private val rnMarigoldModuleImpl = RNMarigoldModuleImpl()
+class RNMarigoldModule(private val reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+    private val rnMarigoldModuleImpl = RNMarigoldModuleImpl(reactContext)
 
     override fun getName(): String {
         return RNMarigoldModuleImpl.NAME
@@ -22,7 +22,7 @@ class RNMarigoldModule(reactContext: ReactApplicationContext) : ReactContextBase
 
     @ReactMethod
     fun registerForPushNotifications() {
-        rnMarigoldModuleImpl.registerForPushNotifications(currentActivity)
+        rnMarigoldModuleImpl.registerForPushNotifications()
     }
 
     @ReactMethod

--- a/android/src/oldarch/com/marigold/rnsdk/RNMessageStreamModule.kt
+++ b/android/src/oldarch/com/marigold/rnsdk/RNMessageStreamModule.kt
@@ -32,6 +32,11 @@ class RNMessageStreamModule(private val reactContext: ReactApplicationContext, d
     }
 
     @ReactMethod
+    fun getMessage(messageId: String, promise: Promise) {
+        rnMessageStreamModuleImpl.getMessage(messageId, promise)
+    }
+
+    @ReactMethod
     fun getMessages(promise: Promise) {
         rnMessageStreamModuleImpl.getMessages(promise)
     }

--- a/android/src/oldarch/com/marigold/rnsdk/RNMessageStreamModule.kt
+++ b/android/src/oldarch/com/marigold/rnsdk/RNMessageStreamModule.kt
@@ -15,7 +15,7 @@ class RNMessageStreamModule(private val reactContext: ReactApplicationContext, d
     }
 
     @VisibleForTesting
-    internal var rnMessageStreamModuleImpl = RNMessageStreamModuleImpl(displayInAppNotifications, inAppNotificationEmitter)
+    internal var rnMessageStreamModuleImpl = RNMessageStreamModuleImpl(reactContext, displayInAppNotifications, inAppNotificationEmitter)
 
     override fun getName(): String {
         return RNMessageStreamModuleImpl.NAME
@@ -68,7 +68,7 @@ class RNMessageStreamModule(private val reactContext: ReactApplicationContext, d
 
     @ReactMethod
     fun presentMessageDetail(message: ReadableMap) {
-        rnMessageStreamModuleImpl.presentMessageDetail(message, reactContext.currentActivity)
+        rnMessageStreamModuleImpl.presentMessageDetail(message)
     }
 
     @ReactMethod

--- a/ios/RNMarigold.mm
+++ b/ios/RNMarigold.mm
@@ -29,7 +29,7 @@ RCT_EXPORT_MODULE();
 
 - (instancetype)init {
     _marigold = [Marigold new];
-    [_marigold setWrapperName:@"React Native" andVersion:@"16.0.0"];
+    [_marigold setWrapperName:@"React Native" andVersion:@"16.1.0"];
     return self;
 }
 

--- a/ios/RNMessageStream.mm
+++ b/ios/RNMessageStream.mm
@@ -112,6 +112,17 @@ RCT_EXPORT_METHOD(useDefaultInAppNotification:(BOOL)useDefault) {
 #pragma mark - Messages
 // Note: We use promises for our return values, not callbacks.
 
+RCT_EXPORT_METHOD(getMessage:(NSString *)messageId resolve:(RCTPromiseResolveBlock)resolve
+                 reject:(RCTPromiseRejectBlock)reject) {
+    [self.messageStream messageFor:messageId withCompletion:^(MARMessage * _Nullable message, NSError * _Nullable error) {
+        if (error) {
+            [RNMessageStream rejectPromise:reject withError:error];
+        } else {
+            resolve([message dictionary]);
+        }
+    }];
+}
+
 RCT_EXPORT_METHOD(getMessages:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     [self.messageStream messages:^(NSArray * _Nullable messages, NSError * _Nullable error) {
         if (error) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "type": "git",
     "url": "git+https://github.com/sailthru/sailthru-mobile-react-native-sdk.git"
   },
-  "version": "16.0.0",
+  "version": "16.1.0",
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",

--- a/src/NativeRNMessageStream.ts
+++ b/src/NativeRNMessageStream.ts
@@ -19,6 +19,7 @@ export interface RNMessage {
 export interface Spec extends TurboModule {
   notifyInAppHandled(handled: boolean): void;
   useDefaultInAppNotification(useDefault: boolean): void;
+  getMessage(messageId: string): Promise<RNMessage>;       
   getMessages(): Promise<Array<RNMessage>>;       
   getUnreadCount(): Promise<number>;
   markMessageAsRead(message: RNMessage): Promise<null>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -88,6 +88,11 @@ declare module 'react-native-marigold' {
      */
     useDefaultInAppNotification(useDefault: boolean): void;
     /**
+     * Asynchronously returns the message for the supplied message ID.
+     * @param messageId The ID of the message to retrieve.
+     */
+    getMessage(messageId: string): Promise<Message>;
+    /**
      * Asynchronously returns an array of messages for the device.
      */
     getMessages(): Promise<Array<Message>>;


### PR DESCRIPTION
This PR:
* Adds the `getMessage` method to retrieve the in-app message associated with the supplied message ID.
* Updates all reference of `currentActivity` in the Android wrapper off the deprecated version and onto the method on the react context.